### PR TITLE
Allow docstring when using terse

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConcreteStructs"
 uuid = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 authors = ["Jonnie Diegelman <jonniediegelman@gmail.com> and contributors"]
-version = "0.2.3"
+version = "0.2.4"
 
 [compat]
 julia = "1.1"

--- a/src/ConcreteStructs.jl
+++ b/src/ConcreteStructs.jl
@@ -64,7 +64,9 @@ FGH{Int64,1,Array{Int64,1},Nothing}
 """
 macro concrete(expr)
     expr, _, _ = _concretize(expr)
-    return esc(expr)
+    return quote
+        $(Base).@__doc__ $expr
+    end |> esc
 end
 
 macro concrete(terse, expr)
@@ -81,7 +83,7 @@ macro concrete(terse, expr)
     end
 
     return quote
-        $expr
+        $(Base).@__doc__ $expr
         function Base.show(io::IO, T::Type{<:$(Symbol(struct_name))})
             if T isa UnionAll
                 print(io, $struct_name)

--- a/src/ConcreteStructs.jl
+++ b/src/ConcreteStructs.jl
@@ -64,9 +64,7 @@ FGH{Int64,1,Array{Int64,1},Nothing}
 """
 macro concrete(expr)
     expr, _, _ = _concretize(expr)
-    return quote
-        $(Base).@__doc__ $expr
-    end |> esc
+    return esc(expr)
 end
 
 macro concrete(terse, expr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,15 @@ end
 plain = Plain()
 
 @concrete terse struct PlainTerse end
-plain = Plain()
+plain_terse = PlainTerse()
+
+"test"
+@concrete struct PlainDoc end
+plain_doc = PlainDoc()
+
+"test"
+@concrete terse struct PlainTerseDoc end
+plain_terse_doc = PlainTerseDoc()
 
 @concrete struct Args
     a


### PR DESCRIPTION
This PR makes it possible to add docstrings to structs using the `@concrete terse ...` pattern.