### PR TITLE
Centralize CI: add Runic, SpellCheck, Downgrade callers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,18 @@ jobs:
     with:
       coverage: false
     secrets: "inherit"
+  runic:
+    name: Runic
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"
+  spellcheck:
+    name: Spell Check
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"
+  downgrade:
+    name: Downgrade
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/docs/src/walkthrough.md
+++ b/docs/src/walkthrough.md
@@ -17,7 +17,7 @@ julia> complex_whatever = Whatever(1+im, "It's pretty complex")
 Whatever{Complex{Int64}, String}(1 + 1im, "It's pretty complex")
 ```
 
-But maybe we don't want to show the type parameters, since we never cared much about them in the first place. If we want our `struct` to print a little more succintly, we can add the `terse` keyword. Now it will print as if we never added the `@concrete` macro.
+But maybe we don't want to show the type parameters, since we never cared much about them in the first place. If we want our `struct` to print a little more succinctly, we can add the `terse` keyword. Now it will print as if we never added the `@concrete` macro.
 
 ```jldoctest prettier-whatever
 julia> @concrete terse struct PrettierWhatever

--- a/src/ConcreteStructs.jl
+++ b/src/ConcreteStructs.jl
@@ -75,7 +75,7 @@ macro concrete(terse, expr)
     expr, struct_name, type_params = _concretize(expr)
     struct_name = string(struct_name)
     num_params = length(type_params)
-    
+
     terse_string = if num_params == 0
         struct_name
     else
@@ -85,7 +85,7 @@ macro concrete(terse, expr)
     return quote
         $(Base).@__doc__ $expr
         function Base.show(io::IO, T::Type{<:$(Symbol(struct_name))})
-            if T isa UnionAll
+            return if T isa UnionAll
                 print(io, $struct_name)
             else
                 print(io, $(struct_name) * "{" * join(T.parameters[1:$num_params], ",") * "}")
@@ -110,7 +110,7 @@ function _concretize(expr)
     struct_name, type_params, super = _parse_head(expr.args[2])
     line_tuples = _parse_line.(expr.args[3].args)
     lines = first.(line_tuples)
-    type_params_full = (type_params..., filter(x -> x!==nothing, last.(line_tuples))...)
+    type_params_full = (type_params..., filter(x -> x !== nothing, last.(line_tuples))...)
 
     struct_type = if length(type_params_full) == 0
         struct_name
@@ -122,7 +122,7 @@ function _concretize(expr)
     constructor_expr = _make_constructor(struct_name, type_params, type_params_full, lines)
     body = Expr(:block, lines..., constructor_expr)
     struct_expr = Expr(:struct, is_mutable, head, body)
-    
+
     struct_expr = _apply_original_expr(original_expr, struct_expr)
 
     return struct_expr, struct_name, type_params
@@ -131,9 +131,9 @@ end
 
 # Make the inner constructor function
 function _make_constructor(struct_name, type_params, type_params_full, lines)
-    lines = map(line->line isa Expr && line.head==:(=) ? line.args[1] : line, lines)
+    lines = map(line -> line isa Expr && line.head == :(=) ? line.args[1] : line, lines)
     field_lines = filter(line -> ((line isa Expr) && (line.head === :(::))), lines)
-    args = map(x->x.args, field_lines)
+    args = map(x -> x.args, field_lines)
     vars = first.(args)
     var_types = last.(args)
     constructor_params = _get_constructor_params(type_params, var_types)
@@ -141,7 +141,7 @@ function _make_constructor(struct_name, type_params, type_params_full, lines)
 
     if length(type_params) == length(type_params_full) && all(type_params .== type_params_full)
         return Expr(:block)
-    elseif length(constructor_params)==0
+    elseif length(constructor_params) == 0
         return :(
             function $struct_name($(field_lines...)) where {$(type_params_full...)}
                 return new{$(new_params...)}($(vars...))
@@ -157,7 +157,7 @@ function _make_constructor(struct_name, type_params, type_params_full, lines)
 end
 
 
-# Get the parameters that are unmatched to variables and need to be annoted in the constructor
+# Get the parameters that are unmatched to variables and need to be annotated in the constructor
 function _get_constructor_params(type_params, var_types)
     subparams = _get_subparams(type_params)
     type_params = _strip_super(type_params)
@@ -194,7 +194,7 @@ function _parse_head(head::Expr)
         super = head.args[2]
         struct_name, type_params = _parse_head(head.args[1])
     end
-    
+
     return (struct_name, type_params, super)
 end
 
@@ -219,18 +219,18 @@ function _parse_line(line::Expr)
         field = line.args[1]
         T = line.args[2]
         sym = Symbol(:__T_, field)
-        (:($field::$sym), :($sym<:$T))
+        (:($field::$sym), :($sym <: $T))
     else
         (line, annotation)
     end
 
     return if assignment
-        (:($(out[1])=$val), out[2])
+        (:($(out[1]) = $val), out[2])
     else
         out
     end
 
-    
+
     # if (T isa Symbol && isdefined(Base.Main, T) && !isconcretetype(Base.eval(Base.Main, T))) || T isa Expr
     #     sym = Symbol("__T_" * string(field))
     #     return (:($field::$sym), :($sym<:$T))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,12 +13,12 @@ line_number_node = LineNumberNode(1)
 annotated_abstract = :(b::AbstractFloat)
 annotated_concrete = :(b::Float64)
 struct_name = :(MyStruct)
-sub_typed_params = :(MyStruct{T1,T2<:AbstractVector{T1}})
+sub_typed_params = :(MyStruct{T1, T2 <: AbstractVector{T1}})
 sub_typed = :(MyStruct{D} <: Number)
-kitchen_sink = :(MyStruct{T1, T2<:AbstractVector{T1}} <: AbstractVector{T1})
-plain_assignment = :(a=1)
-annotated_assignment = :(a::Float64=2.0)
-subtype_annotated_assignment = :(a<:Real=2.0)
+kitchen_sink = :(MyStruct{T1, T2 <: AbstractVector{T1}} <: AbstractVector{T1})
+plain_assignment = :(a = 1)
+annotated_assignment = :(a::Float64 = 2.0)
+subtype_annotated_assignment = :(a <: Real = 2.0)
 
 
 # Run tests
@@ -43,7 +43,7 @@ subtype_annotated_assignment = :(a<:Real=2.0)
 
     @testset "_parse_struct_def" begin
         @test _parse_struct_def(struct_name) == (struct_name, [])
-        @test _parse_struct_def(sub_typed_params) == (struct_name, [:T1, :(T2<:AbstractVector{T1})])
+        @test _parse_struct_def(sub_typed_params) == (struct_name, [:T1, :(T2 <: AbstractVector{T1})])
     end
 
     @testset "_parse_head" begin
@@ -54,19 +54,19 @@ subtype_annotated_assignment = :(a<:Real=2.0)
 
     @testset "_strip_super" begin
         @test _strip_super(struct_name) == struct_name
-        @test _strip_super(kitchen_sink) == :(MyStruct{T1, T2<:AbstractVector{T1}})
+        @test _strip_super(kitchen_sink) == :(MyStruct{T1, T2 <: AbstractVector{T1}})
         @test _strip_super([struct_name, sub_typed]) == [struct_name, :(MyStruct{D})]
     end
 
     @testset "_get_subparams" begin
         @test _get_subparams(struct_name) == []
-        @test _get_subparams([:T1, :(T2<:AbstractArray{T1,N}), :(T3<:Complex{T1})]) == Any[:T1, :N, :T1]
+        @test _get_subparams([:T1, :(T2 <: AbstractArray{T1, N}), :(T3 <: Complex{T1})]) == Any[:T1, :N, :T1]
     end
 
     @testset "_get_constructor_params" begin
-        @test _get_constructor_params([:T, :(A<:AbstractVector{T})], [:A, :B]) == []
-        @test _get_constructor_params([:iip, :T, :(A<:AbstractVector{T})], [:A, :B]) == [:iip]
-        @test _get_constructor_params([:iip, :T, :(A<:AbstractVector{T}), :B], [:B]) == [:iip, :A]
+        @test _get_constructor_params([:T, :(A <: AbstractVector{T})], [:A, :B]) == []
+        @test _get_constructor_params([:iip, :T, :(A <: AbstractVector{T})], [:A, :B]) == [:iip]
+        @test _get_constructor_params([:iip, :T, :(A <: AbstractVector{T}), :B], [:B]) == [:iip, :A]
     end
 end
 
@@ -92,19 +92,19 @@ plain_terse_doc = PlainTerseDoc()
     a
     b
 end
-args = Args(1+im, "hi")
+args = Args(1 + im, "hi")
 
 @concrete terse struct ArgsTerse <: Number
     a
     b
 end
-args_terse = ArgsTerse(1+im, "hi")
+args_terse = ArgsTerse(1 + im, "hi")
 
 @concrete mutable struct SubtypedMutable <: Number
     a
     b
 end
-subtyped_mutable = SubtypedMutable(3.0, 4f0)
+subtyped_mutable = SubtypedMutable(3.0, 4.0f0)
 
 @concrete struct Partial{A}
     # Hey there, I'm a comment
@@ -113,26 +113,26 @@ subtyped_mutable = SubtypedMutable(3.0, 4f0)
     "And I'm a docsctring"
     b
 end
-partial = Partial(:yo, 1//2)
+partial = Partial(:yo, 1 // 2)
 
-@concrete mutable struct ConstructorMutable{iip,C}
+@concrete mutable struct ConstructorMutable{iip, C}
     a
     b
     c::C
 end
-ConstructorMutable(a,b,c) = ConstructorMutable{true}(a,b,eltype(a)(c))
-constructor_mutable = ConstructorMutable([1.0+im, 2], 'r', 1.5)
+ConstructorMutable(a, b, c) = ConstructorMutable{true}(a, b, eltype(a)(c))
+constructor_mutable = ConstructorMutable([1.0 + im, 2], 'r', 1.5)
 constructor_mutable.b = 'h'
 
 @concrete terse struct TerseSameType{A}
     a::A
     b::A
 end
-function TerseSameType(a::A, b::B) where {A,B}
+function TerseSameType(a::A, b::B) where {A, B}
     T = promote_type(A, B)
     return TerseSameType{T}(T(a), T(b))
 end
-terse_same_type = TerseSameType(1+im, 5f0)
+terse_same_type = TerseSameType(1 + im, 5.0f0)
 
 @concrete terse struct FullyParameterized{B}
     a::Symbol
@@ -140,7 +140,7 @@ terse_same_type = TerseSameType(1+im, 5f0)
 end
 fully_parameterized = FullyParameterized(:sine, sin)
 
-@concrete mutable struct ParameterizedSubtyped{T,N,B<:AbstractArray{T,N}} <: AbstractArray{T,N}
+@concrete mutable struct ParameterizedSubtyped{T, N, B <: AbstractArray{T, N}} <: AbstractArray{T, N}
     a
     b::B
     c::T
@@ -155,7 +155,7 @@ Base.getindex(x::ParameterizedSubtyped, i...) = x.b[i...]
 end
 hanging_type_param = HangingTypeParam{true}(1, 2.0)
 
-@concrete terse struct HangingTypeParam2{iip,B}
+@concrete terse struct HangingTypeParam2{iip, B}
     a
     b::B
 end
@@ -165,17 +165,17 @@ hanging_type_param2 = HangingTypeParam2{true}(1, 2.0)
 Base.@kwdef @concrete struct KWDef
     a = "ayyy"
     b::Float64 = 4.0
-    c<:Real = 3
+    c <: Real = 3
     d
     e::Float64
-    f<:Real
+    f <: Real
 end
-kwdef = KWDef(d="hi", e=2.0, f=1//2)
+kwdef = KWDef(d = "hi", e = 2.0, f = 1 // 2)
 
 
 # Run tests
 @testset "End-to-end tests" begin
-    @test_throws ErrorException args.a = 2+im
+    @test_throws ErrorException args.a = 2 + im
     @test_throws MethodError subtyped_mutable.a = "hi"
 
     @test typeof(partial) |> isconcretetype
@@ -191,10 +191,10 @@ kwdef = KWDef(d="hi", e=2.0, f=1//2)
 end
 
 @testset "Issue #3" begin
-    @concrete struct Foo{T<:Real}
+    @concrete struct Foo{T <: Real}
         x::T
-        y<:Real
-        z<:AbstractMatrix{T}
+        y <: Real
+        z <: AbstractMatrix{T}
     end
 
     foo = Foo(1, 1.0, [1, 2]')
@@ -205,7 +205,7 @@ end
 
 @testset "Commutation with other Macros" begin
     # this has been working for a while already
-    Base.@kwdef @concrete struct Foo2{T<:Real}
+    Base.@kwdef @concrete struct Foo2{T <: Real}
         x::T = 1.0
         y = true
         z = 42
@@ -215,7 +215,7 @@ end
     @test typeof(foo) === Foo2{Float64, Bool, Int64}
 
     # this is new
-    @concrete Base.@kwdef struct Foo3{T<:Real}
+    @concrete Base.@kwdef struct Foo3{T <: Real}
         x::T = 1.0
         y = true
         z = 42
@@ -224,7 +224,7 @@ end
     foo = Foo3()
     @test typeof(foo) === Foo3{Float64, Bool, Int64}
 
-    foo = Foo3(z=[1, 2, 3])
+    foo = Foo3(z = [1, 2, 3])
     @test typeof(foo) === Foo3{Float64, Bool, Vector{Int64}}
 
     # terse test case, unfortunately doesn't work the other way around. But also never did.


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

## What this does

Completes the migration of CI to the SciML centralized reusable workflows. Tests and Documentation were already centralized callers; this PR adds the remaining checks and applies the resulting formatting/spelling fixes.

### Added central callers (`@v1`, `secrets: "inherit"`)
- **Runic** (`runic.yml@v1`) — new
- **SpellCheck** (`spellcheck.yml@v1`) — new
- **Downgrade** (`downgrade.yml@v1`, `julia-version: lts`, `skip: Pkg,TOML`) — new

### Already centralized (unchanged, `secrets: "inherit"` confirmed)
- **Tests** (`tests.yml@v1`) — version matrix (min/lts/1/pre × ubuntu-latest × x64) preserved exactly
- **Documentation** (`documentation.yml@v1`, `coverage: false`) preserved

### Formatting / spelling
- Applied Runic formatting to `src/ConcreteStructs.jl` and `test/runtests.jl`.
- Fixed 2 typos: `succintly`→`succinctly` (docs/src/walkthrough.md), `annoted`→`annotated` (src comment).

### Cleanup
- No `CompatHelper.yml` present (nothing to delete).
- `dependabot.yml` already has the correct `github-actions` (/, weekly) and `julia` (/, /docs, /test, daily, grouped) blocks; no `crate-ci/typos` ignore present. Left unchanged.
- `TagBot.yml` unchanged.

> ⚠️ Check names change (new Runic / Spell Check / Downgrade jobs). Branch-protection required-status-checks may need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)