### PR TITLE
Add downgrade CI (centralized inherit form, allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,23 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  downgrade:
+    name: "Downgrade"
+    strategy:
+      matrix:
+        julia-version: ['1.10']
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      skip: "Pkg,TOML"
+    secrets: "inherit"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft. Adds downgrade CI via the centralized inherit-form workflow (allow-reresolve defaults false = genuine test-at-floor). Verified locally, 0 re-resolve. CI is the gate. 🤖 Generated with [Claude Code](https://claude.com/claude-code)