### PR TITLE
Add standard SciML workflows: FormatCheck and SpellCheck

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,16 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,9 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  typos-check:
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
> Ignore until reviewed by @ChrisRackauckas.

Brings ConcreteStructs.jl to full SciML CI uniformization by adding the two genuinely-missing standard workflows:

- **FormatCheck.yml** — Runic format check via the centralized caller `SciML/.github/.github/workflows/runic.yml@v1` (ConcreteStructs uses Runic; copied exactly from the current ADTypes.jl form).
- **SpellCheck.yml** — Spell check via the centralized caller `SciML/.github/.github/workflows/spellcheck.yml@v1`.

Both use `secrets: "inherit"` and the standard triggers/permissions from the central-caller form. No other files are touched.

Note: prior merged PRs (#35, #37) had titles mentioning Runic/SpellCheck but did not actually add these standalone workflow files — verified that `main` currently lacks `FormatCheck.yml` and `SpellCheck.yml`.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>