### PR TITLE
Fix undefined `nerror` (typo for `error`) on the invalid-@concrete path

### DIFF
--- a/src/ConcreteStructs.jl
+++ b/src/ConcreteStructs.jl
@@ -251,7 +251,7 @@ function _find_struct_def(expr; tl_expr = expr)
     elseif expr.head == :macrocall
         return _find_struct_def(expr.args[3]; tl_expr = tl_expr)
     end
-    return nerror("Invalid usage of @concrete.")
+    return error("Invalid usage of @concrete.")
 end
 
 # finds where the struct is defined in original_expr and plugs in struct_expr

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,3 +235,11 @@ end
     terse_kw_def = TerseKWDef(b = false)
     @test typeof(terse_kw_def) === TerseKWDef{Float64, Bool}
 end
+
+@testset "Invalid usage error path" begin
+    # `@concrete` applied to something that is neither a struct definition nor a
+    # macrocall wrapping one reaches `_find_struct_def`'s fallthrough, which must
+    # raise a clear `ErrorException` (previously a `nerror` typo made this throw
+    # an `UndefVarError` instead).
+    @test_throws "Invalid usage of @concrete." @macroexpand(@concrete x = 1)
+end


### PR DESCRIPTION
JET flagged an undefined binding in `src/ConcreteStructs.jl`:

```
src/ConcreteStructs.jl:254: nerror("Invalid usage of @concrete.")
```

`_find_struct_def` is supposed to raise a clear error when `@concrete` is applied to an expression that is neither a `:struct` definition nor a `:macrocall` wrapping one. But the fallthrough called `nerror`, which is undefined — a typo for `error`. As a result, on that invalid-usage path the macro threw `UndefVarError(:nerror)` instead of the intended `ErrorException("Invalid usage of @concrete.")`. Existing tests never exercised that path, so the bug stayed latent.

## Fix

- Change `nerror(` to `error(` at `src/ConcreteStructs.jl:254`. `nerror` is defined nowhere in the package (confirmed via grep), so it really is a typo.

## Test

- Added an "Invalid usage error path" testset in `test/runtests.jl` that exercises the path via `@macroexpand(@concrete x = 1)` (an `=` expression reaches the fallthrough) and asserts:

```julia
@test_throws "Invalid usage of @concrete." @macroexpand(@concrete x = 1)
```

Verified locally on Julia 1.11:
- Before the fix: the new test FAILS — the thrown message is `UndefVarError: \`nerror\` not defined in \`ConcreteStructs\``.
- After the fix: the new test PASSES (`ErrorException` with the "Invalid usage of @concrete." message), and the full suite is green (40/40).

Ignore until reviewed by @ChrisRackauckas.