### PR TITLE
Fix: declare Pkg as a test dep (grouped-tests Core group regression)

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Conversion #40 made `test/runtests.jl` do `using Pkg` (for the QA group's `Pkg.activate`) but didn't declare `Pkg` as a test dep, so the **Core** job (`project='.'`) failed with `ArgumentError: Package Pkg not found` before any test ran — main CI is red because of it. Fix: add `Pkg` to `test/Project.toml`. Verified locally (Julia 1.11): GROUP=Core 39 tests pass, GROUP=QA passes (Aqua 11/11, JET 1/1). Same pattern affects the other B/C conversions; sweeping them. Ignore until reviewed by @ChrisRackauckas.