### PR TITLE
test: add missing `using Test` to runtests.jl (fixes @testset UndefVarError)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Pkg
+using Test
 
 const GROUP = get(ENV, "GROUP", "All")
 


### PR DESCRIPTION
## Problem

`test/runtests.jl` opens with `using Pkg` but never imports `Test`. It then calls `@testset`/`@test_throws` at the top level (the "Invalid usage error path" block), so the test process dies with:

```
UndefVarError: `@testset` not defined
```

This is a test-harness scaffolding bug introduced by the grouped-tests conversion (the top-level `@testset` was added to `runtests.jl` itself, which unlike `core.jl` has no `using Test`). It breaks the **Core**, **downgrade**, and **All**-group CI.

## Fix

Add the missing `using Test` immediately after `using Pkg` so `Test` is in scope before the top-level `@testset`. This is the minimal change — one import line. No test assertions or logic were touched. (`core.jl` already has its own `using Test`.)

## Verification

Ran locally on Julia 1.11:

```
GROUP=Core julia +1.11 --project=. -e 'using Pkg; Pkg.test()'
```

Result — all groups pass, including the previously-failing top-level testset:

```
Test Summary: | Pass  Total  Time
Unit tests    |   23     23  1.7s
End-to-end tests |   11     11
Issue #3      |    1      1
Commutation with other Macros |    4      4
Invalid usage error path |    1      1   <-- was the @testset UndefVarError
     Testing ConcreteStructs tests passed
```

---

Ignore until reviewed by @ChrisRackauckas.