### PR TITLE
Fix JET-flagged may-be-undefined locals failing QA CI

### DIFF
--- a/src/ConcreteStructs.jl
+++ b/src/ConcreteStructs.jl
@@ -193,6 +193,8 @@ function _parse_head(head::Expr)
     elseif head.head === :(<:)
         super = head.args[2]
         struct_name, type_params = _parse_head(head.args[1])
+    else
+        error("Invalid usage of @concrete.")
     end
 
     return (struct_name, type_params, super)
@@ -210,6 +212,7 @@ _parse_line(line) = (line, nothing)
 function _parse_line(line::Expr)
     assignment = line.head === :(=)
     annotation = nothing
+    val = nothing
     if assignment
         val = line.args[2]
         line, annotation = _parse_line(line.args[1])


### PR DESCRIPTION
## What

Fixes the failing QA CI on `main`. The QA group's JET linting (`JET.test_package`, added in #40) reports four **"local variable may be undefined"** errors and fails the `tests / QA (julia 1)` lane:

```
_parse_head(head::Expr) @ src/ConcreteStructs.jl:198
  local variable `struct_name` may be undefined
  local variable `type_params` may be undefined
  local variable `super` may be undefined
_parse_line(line::Expr) @ src/ConcreteStructs.jl:228
  local variable `val` may be undefined
```

These are genuine latent issues in the source, surfaced by the JET lint check that was newly added to the QA group; they are not fixed by skipping/loosening anything.

## Fix (3 lines, behavior-preserving)

- **`_parse_head(head::Expr)`** — the `if head.head === :curly / elseif === :(<:)` chain had no fallthrough, so for any other `head` the three returned locals were undefined. Added an `else` that `error("Invalid usage of @concrete.")`, matching the existing invalid-usage handling in `_find_struct_def`/`_apply_original_expr`. This makes the function total and clears three findings.
- **`_parse_line(line::Expr)`** — `val` was assigned only inside `if assignment`, but its binding is read at the later `if assignment ? ... : ...` site, which JET cannot prove reachable-only-when-defined. Initialized `val = nothing` next to the existing `annotation = nothing`. No behavior change: `val` is only read when `assignment` is true.

## Local verification

- Julia 1.12 (CI's `julia 1`), QA sub-env: `Aqua` 11/11 and `JET` 1/1 pass, **zero JET findings**.
- Julia 1.10 (compat floor), Core group: 40/40 pass, including the invalid-usage assertion.
- Runic `--check` on `src/ConcreteStructs.jl`: clean (exit 0).

Please ignore until reviewed by @ChrisRackauckas.
