### PR TITLE
Bump version to 0.2.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConcreteStructs"
 uuid = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 authors = ["Jonnie Diegelman <jonniediegelman@gmail.com> and contributors"]
-version = "0.2.5"
+version = "0.2.6"
 
 [compat]
 Test = "1"


### PR DESCRIPTION
Automated patch version bump (0.2.5 -> 0.2.6) to release unreleased commits on `main` via JuliaRegistrator.