### PR TITLE
Render ConcreteStructs module docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,6 @@ makedocs(
     ),
     repo = GitHub("jonniedie/ConcreteStructs.jl"),
     authors = "Jonnie Diegelman",
-    warnonly = [:missing_docs],
 )
 
 # Documenter can also automatically deploy documentation to gh-pages.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,3 +1,4 @@
 ```@docs
+ConcreteStructs
 @concrete
 ```


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- Render the `ConcreteStructs` module docstring on the API page.
- Remove `warnonly = [:missing_docs]` from the docs build now that all checked docstrings are included.

## Context

`ConcreteStructs.jl` was updated on `main` by #51 to use the SciMLTesting v2.2 `run_qa` system and remove public API QA workarounds. This follow-up removes the remaining docs missing-docs suppression.

## Validation

- `git diff --check`
- Runic `--check docs/make.jl` with Julia 1.10
- Docs build without `warnonly`: `timeout 3600 env JULIA_DEPOT_PATH=... /home/crackauc/.juliaup/bin/julia +1.10 --project=docs -e "push!(LOAD_PATH, abspath(".")); using Pkg; Pkg.instantiate(); include("docs/make.jl")"`
- QA: `GROUP=QA /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e "using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)"`
  - resolved SciMLTesting v2.2.0
  - `QA/qa.jl | 17 pass | 17 total`