### PR TITLE
Enable rendered docs QA for ConcreteStructs

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,4 +3,4 @@ using JET
 using SciMLTesting
 using Test
 
-run_qa(ConcreteStructs; explicit_imports = true)
+run_qa(ConcreteStructs; explicit_imports = true, api_docs_kwargs = (; rendered = true))


### PR DESCRIPTION
This PR enables the SciMLTesting rendered public API docs check for ConcreteStructs. The package public API probe reports only `@concrete`, which already has a docstring and is rendered on the docs API page.

Ignore this PR until reviewed by @ChrisRackauckas.

Validation run locally:
- `git diff --check`
- `run_qa(ConcreteStructs; explicit_imports = true, api_docs_kwargs = (; rendered = true))`: 18/18 passed
- `Pkg.test()`: all ConcreteStructs core testsets passed
- docs build via `include("docs/make.jl")`: exited 0
- Runic v1.7.0 over `src`, `test`, and `docs`: exited 0
