### PR TITLE
Remove rendered API docs QA override

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,4 +3,4 @@ using JET
 using SciMLTesting
 using Test
 
-run_qa(ConcreteStructs; explicit_imports = true, api_docs_kwargs = (; rendered = true))
+run_qa(ConcreteStructs; explicit_imports = true)


### PR DESCRIPTION
Removes the repository-specific `api_docs_kwargs = (; rendered = true)` override now that ConcreteStructs is on SciMLTesting 2.2.

No docstrings or package code changed.

Validation:
- `Runic.main(["--check", "--docstrings", "."])` with Runic 1.7.0
- `GROUP=QA Pkg.test()` on Julia 1.10
- `Pkg.test()` on Julia 1.10 (40/40)

Please ignore until reviewed by @ChrisRackauckas.