### PR TITLE
Use SciMLTesting default explicit import QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,4 +3,4 @@ using JET
 using SciMLTesting
 using Test
 
-run_qa(ConcreteStructs; explicit_imports = true)
+run_qa(ConcreteStructs)


### PR DESCRIPTION
Removes the redundant `explicit_imports = true` override now that SciMLTesting 2.3 enables it by default.

Local verification: `Pkg.test()` passed with SciMLTesting 2.3.0; Runic check passed.

Ignore until reviewed by @ChrisRackauckas.