### PR TITLE
Require SciMLTesting 2.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.2.6"
 [compat]
 LinearAlgebra = "1"
 SafeTestsets = "0.0.1, 0.1, 1"
-SciMLTesting = "2.2"
+SciMLTesting = "2.4"
 Suppressor = "0.2.8"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,6 +11,6 @@ ConcreteStructs = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
-SciMLTesting = "2.2"
+SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- require the released SciMLTesting 2.4 series in the root test target
- require the same SciMLTesting 2.4 series in the isolated QA environment
- preserve dependency UUIDs and the default SciMLTesting 2.4 strict QA configuration

## Local verification

Release channel:

```text
$ /home/crackauc/.juliaup/bin/julia +release --version
julia version 1.12.5
```

Strict QA and registry version assertion:

```text
$ /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=test/qa -e 'using SciMLTesting; println("SciMLTesting version: ", pkgversion(SciMLTesting)); @assert pkgversion(SciMLTesting) == v"2.4.0"; include("test/qa/qa.jl")'
SciMLTesting version: 2.4.0
Test Summary:     | Pass  Total   Time
Quality Assurance |   21     21  37.2s
```

The initial isolated QA environment instantiation resolved registry `SciMLTesting v2.4.0`; no SciMLTesting source, path, or develop override was used.

Full standard package test:

```text
$ /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
[09d9d899] SciMLTesting v2.4.0
Test Summary:             | Pass  Total  Time
Core/commutation_tests.jl |    4      4  5.3s
Test Summary:            | Pass  Total  Time
Core/end_to_end_tests.jl |   11     11  7.1s
Test Summary:               | Pass  Total  Time
Core/invalid_usage_tests.jl |    1      1  0.1s
Test Summary:   | Pass  Total  Time
Core/issue_3.jl |    1      1  0.5s
Test Summary:      | Pass  Total  Time
Core/unit_tests.jl |   23     23  0.5s
Testing ConcreteStructs tests passed
```

Formatting and diff checks:

```text
$ /home/crackauc/.juliaup/bin/julia +release --startup-file=no --project=.runic-env -m Runic --check .
# Runic v1.7.0; exit 0 with no output
$ git diff --check
# exit 0 with no output
```

No Julia files or subpackages changed; Runic checked all Julia files in the repository. No tests were skipped, silenced, loosened, or removed.
