### PR TITLE
Use strict path-free QA defaults

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,8 @@ makedocs(
     ),
     repo = GitHub("jonniedie/ConcreteStructs.jl"),
     authors = "Jonnie Diegelman",
+    doctest = true,
+    checkdocs = :exports,
 )
 
 # Documenter can also automatically deploy documentation to gh-pages.

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -5,9 +5,6 @@ JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-ConcreteStructs = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"


### PR DESCRIPTION
## Summary
- remove the QA project `[sources]` path now that the standard SciMLTesting runner develops the package under test
- enable Documenter doctests and exported API coverage

## Verification
- `julia +1.12 --project=. -e "using Pkg; Pkg.test()"` (40/40)
- strict SciMLTesting 2.4 QA environment
- doctest/export-check Documenter build through HTML rendering
- Runic and `git diff --check`

Ignore until reviewed by @ChrisRackauckas.