### PR TITLE
Sync package versions with the General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConcreteStructs"
 uuid = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 authors = ["Jonnie Diegelman <jonniediegelman@gmail.com> and contributors"]
-version = "0.2.6"
+version = "0.2.7"
 
 [compat]
 LinearAlgebra = "1"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `ConcreteStructs` | 0.2.6 | 0.2.7 | unreleased changes with no version bump |


## Why

Each `to` is the next sequential version after what is currently registered in
General. Versions that skip an unregistered version are rejected by AutoMerge's
sequential version number guideline, so they can never be registered as-is;
packages with unreleased changes and no bump cannot be registered at all.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).