### PR TITLE
Fix strict QA environment dependencies

### DIFF
--- a/src/ConcreteStructs.jl
+++ b/src/ConcreteStructs.jl
@@ -29,22 +29,22 @@ julia> @concrete struct AB
            b
        end
 
-julia> ab = AB("hi", 1+im)
+julia> ab = AB("hi", 1 + im)
 AB{String, Complex{Int64}}("hi", 1 + 1im)
 
 julia> @concrete terse mutable struct CDE{D} <: Number
-            d::D
-            c
-            e::Symbol
-        end
+           d::D
+           c
+           e::Symbol
+       end
 
-julia> cde = CDE(1f0, (1,2.0), :yo)
+julia> cde = CDE(1.0f0, (1, 2.0), :yo)
 CDE{Float32}(1.0f0, (1, 2.0), :yo)
 
 julia> typeof(cde)
 CDE{Float32,Tuple{Int64, Float64}}
 
-julia> @concrete terse struct FGH{T,N,G<:AbstractArray{T,N}} <: AbstractArray{T,N}
+julia> @concrete terse struct FGH{T, N, G <: AbstractArray{T, N}} <: AbstractArray{T, N}
            f
            g::G
            h::T
@@ -54,7 +54,7 @@ julia> Base.size(x::FGH) = size(x.g);
 
 julia> Base.getindex(x::FGH, i...) = getindex(x.g[i...]);
 
-julia> fgh = FGH(nothing, [1,2,3], 4)
+julia> fgh = FGH(nothing, [1, 2, 3], 4)
 3-element FGH{Int64,1,Vector{Int64}}:
  1
  2

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -2,12 +2,14 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
+SafeTestsets = "0.0.1, 0.1, 1"
 SciMLTesting = "2.4"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary
- Declare `SafeTestsets` directly in the source-free `test/qa` environment, as required by SciMLTesting's isolated group runner.
- Apply Runic formatting to the existing `@concrete` public docstring examples.
- Retain plain `run_qa(ConcreteStructs)`, SciMLTesting `2.4` compat, rendered exported API docs, and no `[sources]` override.

## Verification
- `julia +1.10 --project=. -e 'using Pkg; Pkg.test()'` passed: Core 40/40.
- `GROUP=QA julia +1.10 --project=. test/runtests.jl` passed: QA 12/12 with SciMLTesting 2.6.1 under the package's `2.4` compat.
- Full Documenter build passed doctests, document checks, and HTML rendering.
- Runic (`--check --docstrings .`) and `git diff --check` passed.